### PR TITLE
build: set importHelpers to false for tslib compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "ES5",
-    "importHelpers": true,
+    "importHelpers": false,
     "sourceMap": true,
     "lib": ["DOM", "ES2015", "es2016.array.include", "es2017.object"],
     "composite": true,


### PR DESCRIPTION
closes #31 

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary
Applies the same fix as https://github.com/lineupjs/lineupjs/pull/424 for LineUpEngine. 
