### PR TITLE
fix: changed setTimeout to self.setTimeout for type-safety

### DIFF
--- a/src/internal/scroll.ts
+++ b/src/internal/scroll.ts
@@ -100,9 +100,8 @@ class ScrollHandler {
       if (handler.handler.length === 0) {
         return;
       }
-      // eslint-disable-next-line no-restricted-globals
-      // eslint-disable-next-line no-param-reassign
-      handler.timer = setTimeout(() => {
+      // eslint-disable-next-line no-param-reassign, no-restricted-globals
+      handler.timer = self.setTimeout(() => {
         this.handle(handler);
         // eslint-disable-next-line no-param-reassign
         handler.timer = -1;


### PR DESCRIPTION
**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary
By default, the NodeJS timeout typing is used, which causes the following compile error:

**EDIT:** This happens with `yarn < 2.0` and is fixed by doing `yarn set version berry`. Therefore the runtime environment determines if the build is successful. This PR is therefore actually obsolete, but I guess it should be merged nonetheless?
What do you think @sgratzl?

```
> webpack --mode production --devtool source-map

assets by status 57.4 KiB [cached] 2 assets
Entrypoint lineupengine = lineupengine.css lineupengine.js 2 auxiliary assets
orphan modules 133 KiB [orphan] 21 modules
runtime modules 670 bytes 3 modules
code generated modules 133 KiB (javascript) 4.83 KiB (css/mini-extract) [code generated]
  ./src/bundle.ts + 21 modules 133 KiB [built] [code generated]
  css ./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/style.scss 4.83 KiB [code generated]

ERROR in src/internal/scroll.ts:105:7
TS2322: Type 'Timeout' is not assignable to type 'number'.
    103 |       // eslint-disable-next-line no-restricted-globals
    104 |       // eslint-disable-next-line no-param-reassign
  > 105 |       handler.timer = setTimeout(() => {
        |       ^^^^^^^^^^^^^
    106 |         this.handle(handler);
    107 |         // eslint-disable-next-line no-param-reassign
    108 |         handler.timer = -1;

webpack 5.27.2 compiled with 1 error in 5001 ms
```